### PR TITLE
Sort the size column always by byte size

### DIFF
--- a/src/requestTemplate.html
+++ b/src/requestTemplate.html
@@ -9,7 +9,7 @@
 	</td>
 	<td class="status" data-toggle="tooltip" title="{fullStatus}">{status}</td>
 	<td class="type" data-toggle="tooltip" title="{fullMimeType}">{mime}</td>
-	<td class="size" data-toggle="tooltip" title="{size} ([compressed])<br>{fullSize} ([normal])">{sizeToShow}</td>
+	<td class="size" data-toggle="tooltip" data-sort-value="{size}" title="{size} ([compressed])<br>{fullSize} ([normal])">{sizeToShow}</td>
 	<td class="timeline" data-toggle="popover" title="{progressStart}" data-content="{progressContent}">
 		<div>
 			<div class="progress">


### PR DESCRIPTION
Hi Rafael,
before the sorting of the size column was done on the actual value that was outputed (in bytes, kb, mb etc), now it is always sorted as bytes.

Best
Peter
